### PR TITLE
fixes issue with output selector list being empty in wave link 2.0.0 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ def mainClassPackage = 'com.kylergib.wavelinktp'
 group mainClassPackage
 def versionMajor = 2
 def versionMinor = 0
-def versionPatch = 2
+def versionPatch = 3
 version versionMajor + '.' + versionMinor + '.' + versionPatch
 def versionCode = versionMajor * 1000 + versionMinor * 100 + versionPatch
 

--- a/src/main/java/com/kylergib/wavelinktp/model/Status.java
+++ b/src/main/java/com/kylergib/wavelinktp/model/Status.java
@@ -300,23 +300,23 @@ public abstract class Status {
         allOutputs.clear();
         int id = (int) outputs.get("id");
         JSONObject resultJson = (JSONObject) outputs.get("result");
-        String selectedOutput = (String) resultJson.get("selectedOutput");
-        JSONArray newOutputs = (JSONArray) resultJson.get("outputs");
+        JSONObject selectedOutputs = (JSONObject) resultJson.get("selectedOutput");
+        String localSelectedOutput = (String) selectedOutputs.get("localMixer");
+        JSONObject newOutputs = (JSONObject) resultJson.get("outputs");
+        JSONArray newLocalOutputs = (JSONArray) newOutputs.get("localMixer");
 
-        for (int i = 0; i < newOutputs.length(); i++) {
-            JSONObject tempJson = (JSONObject) newOutputs.get(i);
+        for (int i = 0; i < newLocalOutputs.length(); i++) {
+            JSONObject tempJson = (JSONObject) newLocalOutputs.get(i);
             String identifier = (String) tempJson.get("identifier");
             String name = identifier.contains("SystemDefault") ? "System Default" : (String) tempJson.get("name");
             Boolean isSelected = false;
             Output newOutput = new Output(identifier, name, isSelected);
-            if (identifier.equals(selectedOutput)) {
+            if (identifier.equals(localSelectedOutput)) {
                 newOutput.setSelected(true);
                 currentOutputLocal = newOutput;
-                selectedOutput = newOutput.getName();
+                localSelectedOutput = newOutput.getName();
                 selectedOutputFinished = newOutput.getName();
             }
-
-
             allOutputs.add(newOutput);
 
 

--- a/src/main/java/com/kylergib/wavelinktp/model/WaveLinkClient.java
+++ b/src/main/java/com/kylergib/wavelinktp/model/WaveLinkClient.java
@@ -90,6 +90,8 @@ public class WaveLinkClient extends WebSocketClient {
             else if (lastBroadcastSent != -4 && (System.currentTimeMillis() - lastBroadcastSent)/1000 < WaveLinkPlugin.broadcastTimerInt) {
                 WaveLinkPlugin.LOGGER.log(Level.FINER, "Broadcast timer is skipped because timer has not been initialized or greater than timer integer.");
                 return;
+            } else if (true) { // disables realtime for wl 2.0
+                return;
             }
 
             JSONObject params = (JSONObject) newReceive.get("params");


### PR DESCRIPTION
…and above. this most likely breaks any wave link version that starts with 1

disables the real time audio levels because it was incompatible with wave link 2.0.0 and above